### PR TITLE
Add check for plugin version before caching it

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ replace (
 )
 
 require (
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/gorilla/mux v1.8.0
 	github.com/rancher/lasso v0.0.0-20220628160937-749b3397db38
 	github.com/rancher/wrangler v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/pkg/controllers/plugin/controller.go
+++ b/pkg/controllers/plugin/controller.go
@@ -9,10 +9,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-const (
-	FilesTxtFilename = "files.txt"
-)
-
 func Register(
 	ctx context.Context,
 	systemNamespace, managedBy string,


### PR DESCRIPTION
This PR fixes a race condition problem happening during the upgrade of a plugin where the CR is applied and processed before the new plugin's files are available and the files of the old version are fetched instead.