### PR TITLE
Add support for k8s 1.26

### DIFF
--- a/charts/ui-plugin-operator/Chart.yaml
+++ b/charts/ui-plugin-operator/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
   catalog.cattle.io/permits-os: linux, windows
   catalog.cattle.io/release-name: ui-plugin-operator
   catalog.cattle.io/display-name: 'UI Plugin Operator'
-  catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.26.0-0'
+  catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.27.0-0'
   catalog.cattle.io/rancher-version: '>= 2.7.0-0 < 2.8.0-0'
 apiVersion: v1
 appVersion: '0.1.1'
@@ -16,4 +16,4 @@ type: application
 keywords:
 - applications
 - infrastructure
-version: 0.2.0
+version: 0.2.1


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/41501

Validated in Rancher 2.7.3 upgraded to 2.7-head (from docker image, upgrades from local cluster from k8s 1.25 to 1.26) with the ui-plugin-operator chart and extensions installed